### PR TITLE
Fix Twig extension

### DIFF
--- a/src/Twig/WebPConversionExtension.php
+++ b/src/Twig/WebPConversionExtension.php
@@ -34,7 +34,8 @@ class WebPConversionExtension extends AbstractExtension
      */
     public function setWebpExtension($html)
     {
-        $fullFilePath = "{$this->projectDir}/public{$html}";
+        $imagePath = parse_url($html, PHP_URL_PATH);
+        $fullFilePath = "{$this->projectDir}/public{$imagePath}";
         $webPPath = WebPConverter::convertedWebPImagePath($fullFilePath);
         $options = [
             'saveFile' => true,


### PR DESCRIPTION
Hello

Thanks for this bundle.

The cb_webp filter only accepts relative path otherwise we get an error.

For exemple, i use liip/imagine-bundle for generate thumnails "on the fly":

`<img src="{{ asset(product.masterImage)| imagine_filter('product_thumbnail') }}">`

but the image_filter return an absolute path, so:

> "The file /var/www/vhosts/domain.fr/httpdocs/publichttps://www.domain.fr/images/cache/thumbnail/images/articles/5e98b48431bc1.jpg\" does not exist "

I propose this fix to get the relative path of ressource in any cases


